### PR TITLE
Changed how rating is displayed on HomeSlide

### DIFF
--- a/src/components/HomeSlide/HomeSlide.jsx
+++ b/src/components/HomeSlide/HomeSlide.jsx
@@ -65,7 +65,7 @@ function HomeSlide(props) {
                         .map((id) => `${genreList.get(id)}`)
                         .join(", ")}
                     </div>
-                    <div className="home-rating">
+                    <div className="home-rating-container">
                       <Rating
                         className="item-rating-stars"
                         emptySymbol="far fa-star"

--- a/src/components/HomeSlide/HomeSlide.scss
+++ b/src/components/HomeSlide/HomeSlide.scss
@@ -47,7 +47,7 @@
   color: $tertiary-color;
 }
 
-.home-rating {
+.home-rating-container {
   display: flex;
   color: $secondary-color;
   font-size: 1.125rem; /* 18px */


### PR DESCRIPTION
- Changed how rating is displayed on HomeSlide. It now displays a fractional 5 star rating based on the movie's rating.
- Changed class name from "home-rating" to "home-rating-container"

![image](https://user-images.githubusercontent.com/14192337/86525556-7a28d400-be3d-11ea-837d-6913f020e96e.png)
